### PR TITLE
fix(movement_service): Reference issues in MapPosition's

### DIFF
--- a/src/com/biocollapse/controller/SimulationController.java
+++ b/src/com/biocollapse/controller/SimulationController.java
@@ -24,7 +24,7 @@ public class SimulationController {
     // Models
     private final List<Hospital> hospitals = new ArrayList<>();
     private final List<Human> humans = new ArrayList<>();
-    private final Map map = new Map();
+    private final Map map = new Map("211124");
     private final Virus virus = new Virus(); //! Probably not needed
 
     // Services
@@ -66,9 +66,9 @@ public class SimulationController {
             humans.add(new Human(
                     false,
                     false,
-                    houses.get(i % houses.size()),
-                    getRandomPosition(workplaces),
-                    getRandomPosition(houses)
+                    houses.get(i % houses.size()).copy(),
+                    getRandomPosition(workplaces).copy(),
+                    houses.get(i % houses.size()).copy()
             ));
         }
         // Creating hospitals
@@ -121,6 +121,7 @@ public class SimulationController {
 
     private void updateHumans() {
         for (Human currentHuman : humans) {
+            currentHuman.updateHumanGoal();
             movementService.move(currentHuman);
             // TODO: Update infections and hospitals
         }

--- a/src/com/biocollapse/model/MapPosition.java
+++ b/src/com/biocollapse/model/MapPosition.java
@@ -94,6 +94,10 @@ public class MapPosition {
     return new MapPosition(row, col - 1);
   }
 
+  public MapPosition copy() {
+    return new MapPosition(this.row, this.col);
+  }
+
   @Override
   public String toString() {
     return "MapPosition{" + "row=" + row + ", col=" + col + '}';


### PR DESCRIPTION
Unfortunately, the MovementService did not work as we would have liked. This was due to the fact that a number of references were passed during initialisation, which meant that the position of the home was manipulated all the time under certain circumstances. 