### PR TITLE
Feat/update infection service

### DIFF
--- a/src/com/biocollapse/controller/SimulationController.java
+++ b/src/com/biocollapse/controller/SimulationController.java
@@ -83,8 +83,8 @@ public class SimulationController {
 
     private void updateHumans() {
         for (Human currentHuman : humans) {
-            if (!currentHuman.isAlive())
-                continue;
+//             if (!currentHuman.isAlive())
+//                 continue;
             movementService.updateHumanGoal(currentHuman, tick);
             movementService.move(currentHuman);
             hospitalService.updateHospitals(hospitals, currentHuman);

--- a/src/com/biocollapse/controller/SimulationController.java
+++ b/src/com/biocollapse/controller/SimulationController.java
@@ -83,8 +83,6 @@ public class SimulationController {
 
     private void updateHumans() {
         for (Human currentHuman : humans) {
-//             if (!currentHuman.isAlive())
-//                 continue;
             movementService.updateHumanGoal(currentHuman, tick);
             movementService.move(currentHuman);
             hospitalService.updateHospitals(hospitals, currentHuman);

--- a/src/com/biocollapse/controller/SimulationController.java
+++ b/src/com/biocollapse/controller/SimulationController.java
@@ -51,7 +51,7 @@ public class SimulationController {
             while (isRunning) {
                 long startTime = System.nanoTime(); // Start time for this frame
 
-                updateHumans();
+                updateSimulation();
 
                 try {
                     // TODO: Find sweet spot. And let user fast forward or slow down (x2 / x0.5)
@@ -81,8 +81,10 @@ public class SimulationController {
         }).start();
     }
 
-    private void updateHumans() {
+    private void updateSimulation() {
+        infectionService.initInfectionUpdates();
         for (Human currentHuman : humans) {
+            infectionService.updateInfectedPositions(currentHuman);
             movementService.updateHumanGoal(currentHuman, tick);
             movementService.move(currentHuman);
             hospitalService.updateHospitals(hospitals, currentHuman);

--- a/src/com/biocollapse/model/Map.java
+++ b/src/com/biocollapse/model/Map.java
@@ -173,11 +173,11 @@ public class Map {
         return this.map;
     }
 
-    private boolean isValidPosition(int row, int col) {
+    public static boolean isValidPosition(int row, int col) {
         return col >= 0 && col < MAP_WIDTH && row >= 0 && row < MAP_HEIGHT;
     }
 
-    private boolean isValidPosition(MapPosition pos) {
+    public static boolean isValidPosition(MapPosition pos) {
         return isValidPosition(pos.getRow(), pos.getCol());
     }
 

--- a/src/com/biocollapse/service/InfectionService.java
+++ b/src/com/biocollapse/service/InfectionService.java
@@ -10,7 +10,14 @@ import src.com.biocollapse.model.Age;
 import java.util.List;
 
 public class InfectionService {
-    boolean[][] infected;
+    private boolean[][] infected;
+    private final int infectionProbability = GlobalConfig.config.getInfectionProbability();
+    private final int effectiveInfectionProbability = GlobalConfig.config.getMaskMandate()
+            ? infectionProbability / GlobalConfig.config.getmaskEffect()
+            : infectionProbability;
+    private final int mortalityRisk = GlobalConfig.config.getMortalityRisk();
+    private final int infectionTime = GlobalConfig.config.getInfectionTime();
+    private final int immunityChance = GlobalConfig.config.getImmunityChance();
 
     public void initInfectionUpdates() {
         this.infected = new boolean[Map.MAP_HEIGHT][Map.MAP_WIDTH];
@@ -81,11 +88,6 @@ public class InfectionService {
      * @param currentTick
      */
     private void infectHumans(Human human, int currentTick) {
-        int infectionProbability = GlobalConfig.config.getInfectionProbability();
-        int effectiveInfectionProbability = GlobalConfig.config.getMaskMandate()
-                ? infectionProbability / GlobalConfig.config.getmaskEffect()
-                : infectionProbability;
-
         MapPosition pos = human.getPos();
         if (infected[pos.getRow()][pos.getCol()]) {
             if (human.isAlive() && !human.isInfected() && !human.isImmune()) {
@@ -106,10 +108,6 @@ public class InfectionService {
      * @param currentTick
      */
     private void updateDeadOrHealed(Human human, int currentTick) {
-        int mortalityRisk = GlobalConfig.config.getMortalityRisk();
-        int infectionTime = GlobalConfig.config.getInfectionTime();
-        int immunityChance = GlobalConfig.config.getImmunityChance();
-
         if (human.isInfected()) {
             Age humanAge = human.getAge();
 

--- a/src/com/biocollapse/service/InfectionService.java
+++ b/src/com/biocollapse/service/InfectionService.java
@@ -10,6 +10,31 @@ import src.com.biocollapse.model.Age;
 import java.util.List;
 
 public class InfectionService {
+    boolean[][] infected;
+
+    public void initInfectionUpdates() {
+        this.infected = new boolean[Map.MAP_HEIGHT][Map.MAP_WIDTH];
+    }
+
+    /**
+     * Marks infected fields in the infected matrix
+     * Warning: initInfectionUdpates has to be called before this function!
+     * 
+     * @param humans
+     * @param infectedPos
+     */
+    public void updateInfectedPositions(Human human) {
+        int infectionRadius = GlobalConfig.config.getInfectionRadius();
+        MapPosition pos = human.getPos();
+        if (human.isInfected() && human.isAlive() && !human.isHospitalized()) {
+            // Check if we have to infect only one field or a radius
+            if (infectionRadius > 1) {
+                markInfectedRadius(pos, infectionRadius);
+            } else {
+                infected[pos.getRow()][pos.getCol()] = true;
+            }
+        }
+    }
 
     /**
      * updates infected, healed and dead humans in the humans list
@@ -19,33 +44,9 @@ public class InfectionService {
      * @param currentTick
      */
     public void updateHumansStatus(List<Human> humans, int currentTick) {
-        boolean[][] infected = new boolean[Map.MAP_HEIGHT][Map.MAP_WIDTH];
-
-        updateInfectedPositions(humans, infected);
-        infectNearbyHumans(humans, infected, currentTick);
-        updateDeadOrHealed(humans, currentTick);
-    }
-
-    /**
-     * collects the positions where there are infected people
-     * 
-     * @param humans
-     * @param infectedPos
-     */
-    private void updateInfectedPositions(List<Human> humans, boolean infected[][]) {
-        int infectionRadius = GlobalConfig.config.getInfectionRadius();
-
-        // iterate over the humans list to find infected humans
         for (Human currentHuman : humans) {
-            MapPosition pos = currentHuman.getPos();
-            if (currentHuman.isInfected() && currentHuman.isAlive() && !currentHuman.isHospitalized()) {
-                // Check if we have to infect only one field or a radius
-                if (infectionRadius > 1) {
-                    infectRadius(pos, infected, infectionRadius);
-                } else {
-                    infected[pos.getRow()][pos.getCol()] = true;
-                }
-            }
+            infectHumans(currentHuman, currentTick);
+            updateDeadOrHealed(currentHuman, currentTick);
         }
     }
 
@@ -56,7 +57,7 @@ public class InfectionService {
      * @param radius
      * @return a list of MapPositions in a specific radius
      */
-    private void infectRadius(MapPosition pos, boolean[][] infected, int radius) {
+    private void markInfectedRadius(MapPosition pos, int radius) {
         int row = pos.getRow();
         int col = pos.getCol();
         // Loop through the square grid around the human, bounded by the infection
@@ -79,21 +80,18 @@ public class InfectionService {
      * @param infectedPos
      * @param currentTick
      */
-    private void infectNearbyHumans(List<Human> humans, boolean[][] infected, int currentTick) {
+    private void infectHumans(Human human, int currentTick) {
         int infectionProbability = GlobalConfig.config.getInfectionProbability();
         int effectiveInfectionProbability = GlobalConfig.config.getMaskMandate()
                 ? infectionProbability / GlobalConfig.config.getmaskEffect()
                 : infectionProbability;
 
-        // Check surrounding positions within the infection radius
-        for (Human currentHuman : humans) {
-            MapPosition pos = currentHuman.getPos();
-            if (infected[pos.getRow()][pos.getCol()]) {
-                if (currentHuman.isAlive() && !currentHuman.isInfected() && !currentHuman.isImmune()) {
-                    if (GlobalRandom.checkProbability(effectiveInfectionProbability)) {
-                        currentHuman.setInfected(true);
-                        currentHuman.setInfectedAt(currentTick);
-                    }
+        MapPosition pos = human.getPos();
+        if (infected[pos.getRow()][pos.getCol()]) {
+            if (human.isAlive() && !human.isInfected() && !human.isImmune()) {
+                if (GlobalRandom.checkProbability(effectiveInfectionProbability)) {
+                    human.setInfected(true);
+                    human.setInfectedAt(currentTick);
                 }
             }
         }
@@ -107,40 +105,38 @@ public class InfectionService {
      * @param config
      * @param currentTick
      */
-    private void updateDeadOrHealed(List<Human> humans, int currentTick) {
+    private void updateDeadOrHealed(Human human, int currentTick) {
         int mortalityRisk = GlobalConfig.config.getMortalityRisk();
         int infectionTime = GlobalConfig.config.getInfectionTime();
         int immunityChance = GlobalConfig.config.getImmunityChance();
 
-        for (Human human : humans) {
-            if (human.isInfected()) {
-                Age humanAge = human.getAge();
+        if (human.isInfected()) {
+            Age humanAge = human.getAge();
 
-                // being an elder or a child increases mortality risk and infection time
-                int effectiveMortalityRisk = humanAge == Age.Adult ? mortalityRisk
-                        : mortalityRisk + mortalityRisk / GlobalConfig.config.getAgeEffect();
-                int effectiveinfectionTime = humanAge == Age.Adult ? infectionTime
-                        : infectionTime + infectionTime / GlobalConfig.config.getAgeEffect();
+            // being an elder or a child increases mortality risk and infection time
+            int effectiveMortalityRisk = humanAge == Age.Adult ? mortalityRisk
+                    : mortalityRisk + mortalityRisk / GlobalConfig.config.getAgeEffect();
+            int effectiveinfectionTime = humanAge == Age.Adult ? infectionTime
+                    : infectionTime + infectionTime / GlobalConfig.config.getAgeEffect();
 
-                // hospitalization decreases mortality risk and infection time
-                effectiveMortalityRisk = human.isHospitalized() ? effectiveMortalityRisk / 4 : effectiveMortalityRisk;
-                effectiveinfectionTime = human.isHospitalized() ? effectiveinfectionTime / 2 : effectiveinfectionTime;
+            // hospitalization decreases mortality risk and infection time
+            effectiveMortalityRisk = human.isHospitalized() ? effectiveMortalityRisk / 4 : effectiveMortalityRisk;
+            effectiveinfectionTime = human.isHospitalized() ? effectiveinfectionTime / 2 : effectiveinfectionTime;
 
-                // if still within infectionTime a human has a probability to die
-                if (currentTick - human.getInfectedAt() <= effectiveinfectionTime) {
-                    if (GlobalRandom.checkProbability(effectiveMortalityRisk)) {
-                        human.setAlive(false);
-                    }
-                } else { // otherwise they are healed and have a chance to become immune
-                    human.setInfected(false);
+            // if still within infectionTime a human has a probability to die
+            if (currentTick - human.getInfectedAt() <= effectiveinfectionTime) {
+                if (GlobalRandom.checkProbability(effectiveMortalityRisk)) {
+                    human.setAlive(false);
+                }
+            } else { // otherwise they are healed and have a chance to become immune
+                human.setInfected(false);
 
-                    // Adults have a better chance at becoming immune than children and the elderly
-                    int effectiveImmunityChance = humanAge == Age.Adult ? immunityChance + immunityChance / 2
-                            : immunityChance;
+                // Adults have a better chance at becoming immune than children and the elderly
+                int effectiveImmunityChance = humanAge == Age.Adult ? immunityChance + immunityChance / 2
+                        : immunityChance;
 
-                    if (GlobalRandom.checkProbability(effectiveImmunityChance)) {
-                        human.setImmune(true);
-                    }
+                if (GlobalRandom.checkProbability(effectiveImmunityChance)) {
+                    human.setImmune(true);
                 }
             }
         }

--- a/src/com/biocollapse/service/InfectionService.java
+++ b/src/com/biocollapse/service/InfectionService.java
@@ -7,66 +7,43 @@ import src.com.biocollapse.util.GlobalConfig;
 import src.com.biocollapse.util.GlobalRandom;
 import src.com.biocollapse.model.Age;
 
-
-import java.util.ArrayList;
 import java.util.List;
-
 
 public class InfectionService {
 
     /**
      * updates infected, healed and dead humans in the humans list
+     * 
      * @param humans
      * @param config
      * @param currentTick
      */
-    public void updateHumansStatus(List<Human> humans,  int currentTick) {
+    public void updateHumansStatus(List<Human> humans, int currentTick) {
+        boolean[][] infected = new boolean[Map.MAP_HEIGHT][Map.MAP_WIDTH];
 
-        ArrayList<MapPosition> infectedPos = new ArrayList<MapPosition>();
-
-        updateInfectedPositions(humans, infectedPos);
-        infectNearbyHumans(humans, infectedPos, currentTick);
+        updateInfectedPositions(humans, infected);
+        infectNearbyHumans(humans, infected, currentTick);
         updateDeadOrHealed(humans, currentTick);
-    } 
-
-    /**
-     * collects the positions where there are infected people
-     * @param humans
-     * @param infectedPos
-     */
-    private void updateInfectedPositions(List<Human> humans, ArrayList<MapPosition> infectedPos) {
-
-        //iterate over the humans list to find infected humans
-        for (Human currentHuman : humans) {
-            if (currentHuman.isInfected() && currentHuman.isAlive() && !currentHuman.isHospitalized()) {
-                infectedPos.add(currentHuman.getPos());
-            }
-        }
     }
 
     /**
-     * infects healthy humans which are in the infection radius of another infected human according to a probability
-     * @param config
+     * collects the positions where there are infected people
+     * 
      * @param humans
      * @param infectedPos
-     * @param currentTick
      */
-    private void infectNearbyHumans(List<Human> humans, ArrayList<MapPosition> infectedPos, int currentTick) {
+    private void updateInfectedPositions(List<Human> humans, boolean infected[][]) {
         int infectionRadius = GlobalConfig.config.getInfectionRadius();
-        int infectionProbability = GlobalConfig.config.getInfectionProbability();
-        int effectiveInfectionProbability = GlobalConfig.config.getMaskMandate() ? infectionProbability / GlobalConfig.config.getmaskEffect() : infectionProbability;
 
-        // Check surrounding positions within the infection radius
-        for (MapPosition pos : infectedPos){
-            for (MapPosition neighbor : getPositionsWithinRadius(pos, infectionRadius)) {
-                ArrayList<Human> neighborHumans = findHumansAtPos(neighbor, humans);
-                for (Human neighborHuman: neighborHumans) {
-                    if (neighborHuman.isAlive() && !neighborHuman.isInfected() && !neighborHuman.isImmune()) {
-                        if (GlobalRandom.checkProbability(effectiveInfectionProbability)) {
-                            neighborHuman.setInfected(true);
-                            neighborHuman.setInfectedAt(currentTick);
-                        }
-                    }
+        // iterate over the humans list to find infected humans
+        for (Human currentHuman : humans) {
+            MapPosition pos = currentHuman.getPos();
+            if (currentHuman.isInfected() && currentHuman.isAlive() && !currentHuman.isHospitalized()) {
+                // Check if we have to infect only one field or a radius
+                if (infectionRadius > 1) {
+                    infectRadius(pos, infected, infectionRadius);
+                } else {
+                    infected[pos.getRow()][pos.getCol()] = true;
                 }
             }
         }
@@ -74,53 +51,58 @@ public class InfectionService {
 
     /**
      * calculate the positions located in a specific radius
+     * 
      * @param pos
      * @param radius
      * @return a list of MapPositions in a specific radius
      */
-    private List<MapPosition> getPositionsWithinRadius(MapPosition pos, int radius) {
-        List<MapPosition> neighbors = new ArrayList<>();
-
-        // Loop through the square grid around the human, bounded by the infection radius
+    private void infectRadius(MapPosition pos, boolean[][] infected, int radius) {
+        int row = pos.getRow();
+        int col = pos.getCol();
+        // Loop through the square grid around the human, bounded by the infection
+        // radius and mark every visited field as infected.
         for (int i = -radius; i <= radius; i++) {
             for (int j = -radius; j <= radius; j++) {
-                MapPosition neighborPos = new MapPosition(pos.getRow() + i, pos.getCol() + j);
-                if (isWithinMapBounds(neighborPos)) {
-                    neighbors.add(neighborPos);
+                if (Map.isValidPosition(row + i, col + j)) {
+                    infected[row + i][col + j] = true;
                 }
             }
         }
-
-        return neighbors;
     }
 
     /**
-     * checks of a calculated position is within the bounds of the Map
-     * @param pos
-     * @return boolean
-     */
-    private boolean isWithinMapBounds(MapPosition pos) {
-        return pos.getRow() >= 0 && pos.getRow() < Map.MAP_HEIGHT && pos.getCol() >= 0 && pos.getCol() < Map.MAP_WIDTH;
-    }
-
-    /**
-     * finds the humans located in a specific MapPosition 
-     * @param position
+     * infects healthy humans which are in the infection radius of another infected
+     * human according to a probability
+     * 
+     * @param config
      * @param humans
-     * @return Human
+     * @param infectedPos
+     * @param currentTick
      */
-    private ArrayList<Human> findHumansAtPos(MapPosition position, List<Human> humans) {
-        ArrayList<Human> humansAtPos = new ArrayList<Human>();
-        for (Human human : humans) {
-            if (human.getPos().equals(position)) {
-                humansAtPos.add(human);
+    private void infectNearbyHumans(List<Human> humans, boolean[][] infected, int currentTick) {
+        int infectionProbability = GlobalConfig.config.getInfectionProbability();
+        int effectiveInfectionProbability = GlobalConfig.config.getMaskMandate()
+                ? infectionProbability / GlobalConfig.config.getmaskEffect()
+                : infectionProbability;
+
+        // Check surrounding positions within the infection radius
+        for (Human currentHuman : humans) {
+            MapPosition pos = currentHuman.getPos();
+            if (infected[pos.getRow()][pos.getCol()]) {
+                if (currentHuman.isAlive() && !currentHuman.isInfected() && !currentHuman.isImmune()) {
+                    if (GlobalRandom.checkProbability(effectiveInfectionProbability)) {
+                        currentHuman.setInfected(true);
+                        currentHuman.setInfectedAt(currentTick);
+                    }
+                }
             }
         }
-        return humansAtPos;
     }
 
     /**
-     * updates the human list with new healed or dead humans according to the parameters
+     * updates the human list with new healed or dead humans according to the
+     * parameters
+     * 
      * @param humans
      * @param config
      * @param currentTick
@@ -134,25 +116,28 @@ public class InfectionService {
             if (human.isInfected()) {
                 Age humanAge = human.getAge();
 
-                //being an elder or a child increases mortality risk and infection time
-                int effectiveMortalityRisk = humanAge == Age.Adult ? mortalityRisk : mortalityRisk + mortalityRisk / GlobalConfig.config.getAgeEffect();
-                int effectiveinfectionTime = humanAge == Age.Adult ? infectionTime : infectionTime + infectionTime / GlobalConfig.config.getAgeEffect();
+                // being an elder or a child increases mortality risk and infection time
+                int effectiveMortalityRisk = humanAge == Age.Adult ? mortalityRisk
+                        : mortalityRisk + mortalityRisk / GlobalConfig.config.getAgeEffect();
+                int effectiveinfectionTime = humanAge == Age.Adult ? infectionTime
+                        : infectionTime + infectionTime / GlobalConfig.config.getAgeEffect();
 
-                //hospitalization decreases mortality risk and infection time
+                // hospitalization decreases mortality risk and infection time
                 effectiveMortalityRisk = human.isHospitalized() ? effectiveMortalityRisk / 4 : effectiveMortalityRisk;
                 effectiveinfectionTime = human.isHospitalized() ? effectiveinfectionTime / 2 : effectiveinfectionTime;
 
-                //if still within infectionTime a human has a probability to die
-                if(currentTick - human.getInfectedAt() <= effectiveinfectionTime) {
+                // if still within infectionTime a human has a probability to die
+                if (currentTick - human.getInfectedAt() <= effectiveinfectionTime) {
                     if (GlobalRandom.checkProbability(effectiveMortalityRisk)) {
                         human.setAlive(false);
                     }
-                } else { //otherwise they are healed and have a chance to become immune
+                } else { // otherwise they are healed and have a chance to become immune
                     human.setInfected(false);
 
-                    //Adults have a better chance at becoming immune than children and the elderly
-                    int effectiveImmunityChance = humanAge == Age.Adult ? immunityChance + immunityChance / 2 : immunityChance;
-                    
+                    // Adults have a better chance at becoming immune than children and the elderly
+                    int effectiveImmunityChance = humanAge == Age.Adult ? immunityChance + immunityChance / 2
+                            : immunityChance;
+
                     if (GlobalRandom.checkProbability(effectiveImmunityChance)) {
                         human.setImmune(true);
                     }


### PR DESCRIPTION
I had a look at the simulation with Lars, who used 10,000 people, and we noticed a slight hiccup in the performance. As long as people were infected, the simulation ran very slowly. But if no more people were infected, it ran at almost the speed of light, which was great!

I have changed the following things so that everything runs more consistently in terms of performance.
I changed the data structure for marking the fields that are infected to a 2D matrix. I also tried to minimise the number of loops in which all people are iterated through.

## warning

This branch depends upon the PR #25 so before you would take a look at this one you should check out the other one.