### PR TITLE
fixed bug: timeToDeath Parameter not being saved when reusing parameters

### DIFF
--- a/src/com/biocollapse/model/Config.java
+++ b/src/com/biocollapse/model/Config.java
@@ -2,313 +2,332 @@
 package src.com.biocollapse.model;
 
 public class Config {
-  private int infectionRadius;
-  private int infectionProbability;
-  private int incubationTime;
-  private int mortalityRisk;
-  private int infectionTime;
-  private int immunityChance;
 
-  private int hospitalCapacity;
-  private int isolationProbability;
-  private int hospitalProbability;
-  private int childrenRatio;
-  private int adultRatio;
-  private int elderlyRatio;
+    private int infectionRadius;
+    private int infectionProbability;
+    private int mortalityRisk;
+    private int immunityChance;
+    private int incubationTime; // Tick asjusted
+    private int configuredIncubationTime; // Actual configured value
+    private int infectionTime; // Tick asjusted
+    private int configuredInfectionTime; // Actual configured value
 
-  private boolean lockdown;
-  private boolean isolationMandate;
-  private boolean maskMandate;
-  private boolean schoolClosure;
-  private int maskEffect = 2; // how much the maskMandate decreases the infectionProbability
-  private int ageEffect = 3; // how much the age of a human increases mortalityRisk
-  private int isolationEffect = 2; // how much the isolationMandate increases the isolationProbability
-  private int lockdownEffect = 75;
-  private int ticksAtLocation = 50; // how many ticks does a person stay at home or at work after reaching the goal
-  private int populationSize = 500;
-  public static final  int SIMULATION_ONE_DAY_TICKS = 250;
-  public static final int SIMULATION_MAX_DAYS = 14;
+    private int hospitalCapacity;
+    private int isolationProbability;
+    private int hospitalProbability;
+    private int childrenRatio;
+    private int adultRatio;
+    private int elderlyRatio;
 
-  /**
-   * @param infectionRadius      The radius in which an infected person can infect
-   *                             another person
-   * @param infectionProbability The probability of an infected person to infect
-   *                             another person
-   * @param incubationTime       The amount of ticks until symptoms show and a
-   *                             person chooses to go to the hospital or not
-   * @param mortalityRisk        The probability of the virus killing a person
-   * @param infectionTime        The amount of ticks after infection in which a
-   *                             person can die
-   * @param immunityChance       The probability of getting immune after surviving
-   *                             an infection
-   * @param hospitalCapacity     The capacity each hospital provides
-   * @param isolationProbability The probabilty for people to isolate themselves
-   * @param hospitalProbability  The probability for people to go into the
-   *                             hospital when infected
-   * @param childrenRatio        The ratio of children inside of the simulation
-   * @param adultRatio           The ratio of adult people inside of the
-   *                             simulation
-   * @param elderlyRatio         The ratio of elderly people inside of the
-   *                             simulation
-   * @param lockdown
-   * @param isolationMandate
-   * @param maskMandate
-   * @param schoolClosure
-   */
-  public Config(int infectionRadius, int infectionProbability, int incubationTime, int mortalityRisk, int infectionTime,
-      int immunityChance, int hospitalCapacity, int isolationProbability, int hospitalProbability,
-      int childrenRatio, int adultRatio, int elderlyRatio, boolean lockdown, boolean isolationMandate,
-      boolean maskMandate, boolean schoolClosure) {
-    setConfig(infectionRadius, infectionProbability, incubationTime, mortalityRisk, infectionTime, immunityChance,
-        hospitalCapacity, isolationProbability, hospitalProbability, childrenRatio, adultRatio, elderlyRatio, lockdown,
-        isolationMandate, maskMandate, schoolClosure);
-  }
+    private boolean lockdown;
+    private boolean isolationMandate;
+    private boolean maskMandate;
+    private boolean schoolClosure;
+    private int maskEffect = 2; // how much the maskMandate decreases the infectionProbability
+    private int ageEffect = 3; // how much the age of a human increases mortalityRisk
+    private int isolationEffect = 2; // how much the isolationMandate increases the isolationProbability
+    private int lockdownEffect = 75;
+    private int ticksAtLocation = 50; // how many ticks does a person stay at home or at work after reaching the goal
+    private int populationSize = 500;
+    public static final int SIMULATION_ONE_DAY_TICKS = 250;
+    public static final int SIMULATION_MAX_DAYS = 14;
 
-  public Config() {
-  }
+    /**
+     * @param infectionRadius The radius in which an infected person can infect
+     * another person
+     * @param infectionProbability The probability of an infected person to
+     * infect another person
+     * @param incubationTime The amount of ticks until symptoms show and a
+     * person chooses to go to the hospital or not
+     * @param mortalityRisk The probability of the virus killing a person
+     * @param infectionTime The amount of ticks after infection in which a
+     * person can die
+     * @param immunityChance The probability of getting immune after surviving
+     * an infection
+     * @param hospitalCapacity The capacity each hospital provides
+     * @param isolationProbability The probabilty for people to isolate
+     * themselves
+     * @param hospitalProbability The probability for people to go into the
+     * hospital when infected
+     * @param childrenRatio The ratio of children inside of the simulation
+     * @param adultRatio The ratio of adult people inside of the simulation
+     * @param elderlyRatio The ratio of elderly people inside of the simulation
+     * @param lockdown
+     * @param isolationMandate
+     * @param maskMandate
+     * @param schoolClosure
+     */
+    public Config(int infectionRadius, int infectionProbability, int incubationTime, int mortalityRisk, int infectionTime,
+            int immunityChance, int hospitalCapacity, int isolationProbability, int hospitalProbability,
+            int childrenRatio, int adultRatio, int elderlyRatio, boolean lockdown, boolean isolationMandate,
+            boolean maskMandate, boolean schoolClosure) {
+        setConfig(infectionRadius, infectionProbability, incubationTime, mortalityRisk, infectionTime, immunityChance,
+                hospitalCapacity, isolationProbability, hospitalProbability, childrenRatio, adultRatio, elderlyRatio, lockdown,
+                isolationMandate, maskMandate, schoolClosure);
+    }
 
-  /**
-   * Allows us to initialize the Config class lazily
-   * 
-   * @param infectionRadius      The radius in which an infected person can infect
-   *                             another person
-   * @param infectionProbability The probability of an infected person to infect
-   *                             another person
-   * @param incubationTime       The amount of ticks it needs until the virus is
-   *                             deadly
-   * @param mortalityRisk        The probability of the virus killing a person
-   * @param infectionTime        The amount of ticks after the incubation time in
-   *                             which a person can die
-   * @param immunityChance       The probability of getting immune after surviving
-   *                             an infection
-   * @param hospitalCapacity     The capacity each hospital provides
-   * @param isolationProbability The probabilty for people to isolate themselves
-   * @param hospitalProbability  The probability for people to go into the
-   *                             hospital when infected
-   * @param childrenRatio        The ratio of children inside of the simulation
-   * @param adultRatio           The ratio of adult people inside of the
-   *                             simulation
-   * @param elderlyRatio         The ratio of elderly people inside of the
-   *                             simulation
-   * @param lockdown
-   * @param isolationMandate
-   * @param maskMandate
-   * @param schoolClosure
-   */
-  public void setConfig(int infectionRadius, int infectionProbability, int incubationTime, int mortalityRisk,
-      int infectionTime,
-      int immunityChance, int hospitalCapacity, int isolationProbability, int hospitalProbability,
-      int childrenRatio, int adultRatio, int elderlyRatio, boolean lockdown, boolean isolationMandate,
-      boolean maskMandate, boolean schoolClosure) {
-    this.infectionRadius = infectionRadius;
-    this.infectionProbability = infectionProbability;
-    this.incubationTime = incubationTime;
-    this.mortalityRisk = mortalityRisk;
-    this.infectionTime = infectionTime;
-    this.immunityChance = immunityChance;
-    this.hospitalCapacity = hospitalCapacity;
-    this.isolationProbability = isolationProbability;
-    this.hospitalProbability = hospitalProbability;
-    this.childrenRatio = childrenRatio;
-    this.adultRatio = adultRatio;
-    this.elderlyRatio = elderlyRatio;
-    this.lockdown = lockdown;
-    this.isolationMandate = isolationMandate;
-    this.maskMandate = maskMandate;
-    this.schoolClosure = schoolClosure;
-  }
+    public Config() {
+    }
 
-  public int getPopulationSize() {
-    return populationSize;
-  }
+    /**
+     * Allows us to initialize the Config class lazily
+     *
+     * @param infectionRadius The radius in which an infected person can infect
+     * another person
+     * @param infectionProbability The probability of an infected person to
+     * infect another person
+     * @param incubationTime The amount of ticks it needs until the virus is
+     * deadly
+     * @param mortalityRisk The probability of the virus killing a person
+     * @param infectionTime The amount of ticks after the incubation time in
+     * which a person can die
+     * @param immunityChance The probability of getting immune after surviving
+     * an infection
+     * @param hospitalCapacity The capacity each hospital provides
+     * @param isolationProbability The probabilty for people to isolate
+     * themselves
+     * @param hospitalProbability The probability for people to go into the
+     * hospital when infected
+     * @param childrenRatio The ratio of children inside of the simulation
+     * @param adultRatio The ratio of adult people inside of the simulation
+     * @param elderlyRatio The ratio of elderly people inside of the simulation
+     * @param lockdown
+     * @param isolationMandate
+     * @param maskMandate
+     * @param schoolClosure
+     */
+    public void setConfig(int infectionRadius, int infectionProbability, int incubationTime, int mortalityRisk,
+            int infectionTime,
+            int immunityChance, int hospitalCapacity, int isolationProbability, int hospitalProbability,
+            int childrenRatio, int adultRatio, int elderlyRatio, boolean lockdown, boolean isolationMandate,
+            boolean maskMandate, boolean schoolClosure) {
+        this.infectionRadius = infectionRadius;
+        this.infectionProbability = infectionProbability;
+        this.incubationTime = incubationTime * Config.SIMULATION_ONE_DAY_TICKS;
+        this.configuredIncubationTime = incubationTime;
+        this.infectionTime = infectionTime * Config.SIMULATION_ONE_DAY_TICKS;
+        this.configuredInfectionTime = infectionTime;
+        this.mortalityRisk = mortalityRisk;
+        this.immunityChance = immunityChance;
+        this.hospitalCapacity = hospitalCapacity;
+        this.isolationProbability = isolationProbability;
+        this.hospitalProbability = hospitalProbability;
+        this.childrenRatio = childrenRatio;
+        this.adultRatio = adultRatio;
+        this.elderlyRatio = elderlyRatio;
+        this.lockdown = lockdown;
+        this.isolationMandate = isolationMandate;
+        this.maskMandate = maskMandate;
+        this.schoolClosure = schoolClosure;
+    }
 
-  public void setPopulationSize(int populationSize) {
-    this.populationSize = populationSize;
-  }
+    public int getPopulationSize() {
+        return populationSize;
+    }
 
-  public int getTicksAtLocation() {
-    return ticksAtLocation;
-  }
+    public void setPopulationSize(int populationSize) {
+        this.populationSize = populationSize;
+    }
 
-  public void setTicksAtLocation(int ticksAtLocation) {
-    this.ticksAtLocation = ticksAtLocation;
-  }
+    public int getTicksAtLocation() {
+        return ticksAtLocation;
+    }
 
-  public int getInfectionRadius() {
-    return infectionRadius;
-  }
+    public void setTicksAtLocation(int ticksAtLocation) {
+        this.ticksAtLocation = ticksAtLocation;
+    }
 
-  public void setInfectionRadius(int infectionRadius) {
-    this.infectionRadius = infectionRadius;
-  }
+    public int getInfectionRadius() {
+        return infectionRadius;
+    }
 
-  public int getInfectionProbability() {
-    return infectionProbability;
-  }
+    public void setInfectionRadius(int infectionRadius) {
+        this.infectionRadius = infectionRadius;
+    }
 
-  public void setInfectionProbability(int infectionProbability) {
-    this.infectionProbability = infectionProbability;
-  }
+    public int getInfectionProbability() {
+        return infectionProbability;
+    }
 
-  public int getIncubationTime() {
-    return incubationTime;
-  }
+    public void setInfectionProbability(int infectionProbability) {
+        this.infectionProbability = infectionProbability;
+    }
 
-  public void setIncubationTime(int incubationTime) {
-    this.incubationTime = incubationTime;
-  }
+    public int getIncubationTime() {
+        return incubationTime;
+    }
 
-  public int getMortalityRisk() {
-    return mortalityRisk;
-  }
+    public void setIncubationTime(int incubationTime) {
+        this.incubationTime = incubationTime;
+    }
 
-  public void setMortalityRisk(int mortalityRisk) {
-    this.mortalityRisk = mortalityRisk;
-  }
+    public int getMortalityRisk() {
+        return mortalityRisk;
+    }
 
-  public int getInfectionTime() {
-    return infectionTime;
-  }
+    public void setMortalityRisk(int mortalityRisk) {
+        this.mortalityRisk = mortalityRisk;
+    }
 
-  public void setInfectionTime(int infectionTime) {
-    this.infectionTime = infectionTime;
-  }
+    public int getInfectionTime() {
+        return infectionTime;
+    }
 
-  public int getImmunityChance() {
-    return immunityChance;
-  }
+    public void setInfectionTime(int infectionTime) {
+        this.infectionTime = infectionTime;
+    }
 
-  public void setImmunityChance(int immunityChance) {
-    this.immunityChance = immunityChance;
-  }
+    public int getImmunityChance() {
+        return immunityChance;
+    }
 
-  public int getHospitalCapacity() {
-    return hospitalCapacity;
-  }
+    public void setImmunityChance(int immunityChance) {
+        this.immunityChance = immunityChance;
+    }
 
-  public void setHospitalCapacity(int hospitalCapacity) {
-    this.hospitalCapacity = hospitalCapacity;
-  }
+    public int getHospitalCapacity() {
+        return hospitalCapacity;
+    }
 
-  public int getIsolationProbability() {
-    return isolationProbability;
-  }
+    public void setHospitalCapacity(int hospitalCapacity) {
+        this.hospitalCapacity = hospitalCapacity;
+    }
 
-  public void setIsolationProbability(int isolationProbability) {
-    this.isolationProbability = isolationProbability;
-  }
+    public int getIsolationProbability() {
+        return isolationProbability;
+    }
 
-  public int getHospitalProbability() {
-    return hospitalProbability;
-  }
+    public void setIsolationProbability(int isolationProbability) {
+        this.isolationProbability = isolationProbability;
+    }
 
-  public void setHospitalProbability(int hospitalProbability) {
-    this.hospitalProbability = hospitalProbability;
-  }
+    public int getHospitalProbability() {
+        return hospitalProbability;
+    }
 
-  public int getChildrenRatio() {
-    return childrenRatio;
-  }
+    public void setHospitalProbability(int hospitalProbability) {
+        this.hospitalProbability = hospitalProbability;
+    }
 
-  public void setChildrenRatio(int childrenRatio) {
-    this.childrenRatio = childrenRatio;
-  }
+    public int getChildrenRatio() {
+        return childrenRatio;
+    }
 
-  public int getAdultRatio() {
-    return adultRatio;
-  }
+    public void setChildrenRatio(int childrenRatio) {
+        this.childrenRatio = childrenRatio;
+    }
 
-  public void setAdultRatio(int adultRatio) {
-    this.adultRatio = adultRatio;
-  }
+    public int getAdultRatio() {
+        return adultRatio;
+    }
 
-  public int getElderlyRatio() {
-    return elderlyRatio;
-  }
+    public void setAdultRatio(int adultRatio) {
+        this.adultRatio = adultRatio;
+    }
 
-  public void setElderlyRatio(int elderlyRatio) {
-    this.elderlyRatio = elderlyRatio;
-  }
+    public int getElderlyRatio() {
+        return elderlyRatio;
+    }
 
-  public boolean getLockdown() {
-    return lockdown;
-  }
+    public void setElderlyRatio(int elderlyRatio) {
+        this.elderlyRatio = elderlyRatio;
+    }
 
-  public void setLockdown(boolean lockdown) {
-    this.lockdown = lockdown;
-  }
+    public boolean getLockdown() {
+        return lockdown;
+    }
 
-  public boolean getIsolationMandate() {
-    return isolationMandate;
-  }
+    public void setLockdown(boolean lockdown) {
+        this.lockdown = lockdown;
+    }
 
-  public void setIsolationMandate(boolean isolateMandate) {
-    this.isolationMandate = isolateMandate;
-  }
+    public boolean getIsolationMandate() {
+        return isolationMandate;
+    }
 
-  public boolean getMaskMandate() {
-    return maskMandate;
-  }
+    public void setIsolationMandate(boolean isolateMandate) {
+        this.isolationMandate = isolateMandate;
+    }
 
-  public void setMaskMandate(boolean maskMandate) {
-    this.maskMandate = maskMandate;
-  }
+    public boolean getMaskMandate() {
+        return maskMandate;
+    }
 
-  public boolean getSchoolClosure() {
-    return schoolClosure;
-  }
+    public void setMaskMandate(boolean maskMandate) {
+        this.maskMandate = maskMandate;
+    }
 
-  public void setSchoolClosure(boolean schoolClosure) {
-    this.schoolClosure = schoolClosure;
-  }
+    public boolean getSchoolClosure() {
+        return schoolClosure;
+    }
 
-  public int getmaskEffect() {
-    return this.maskEffect;
-  }
+    public void setSchoolClosure(boolean schoolClosure) {
+        this.schoolClosure = schoolClosure;
+    }
 
-  public void setMaskEffect(int maskEffect) {
-    this.maskEffect = maskEffect;
-  }
+    public int getmaskEffect() {
+        return this.maskEffect;
+    }
 
-  public int getAgeEffect() {
-    return ageEffect;
-  }
+    public void setMaskEffect(int maskEffect) {
+        this.maskEffect = maskEffect;
+    }
 
-  public void setAgeEffect(int ageEffect) {
-    this.ageEffect = ageEffect;
-  }
+    public int getAgeEffect() {
+        return ageEffect;
+    }
 
-  public int getIsolationEffect() {
-    return isolationEffect;
-  }
+    public void setAgeEffect(int ageEffect) {
+        this.ageEffect = ageEffect;
+    }
 
-  public void setIsolationEffect(int isolationEffect) {
-    this.isolationEffect = isolationEffect;
-  }
+    public int getIsolationEffect() {
+        return isolationEffect;
+    }
 
-  public int getLockdownEffect() {
-    return lockdownEffect;
-  }
+    public void setIsolationEffect(int isolationEffect) {
+        this.isolationEffect = isolationEffect;
+    }
 
-  public void setLockdownEffect(int lockdownEffect) {
-    this.lockdownEffect = lockdownEffect;
-  }
+    public int getLockdownEffect() {
+        return lockdownEffect;
+    }
 
-  @Override
-  public String toString() {
-    return "Config{" +
-        "infectionRadius=" + infectionRadius +
-        ", infectionProbability=" + infectionProbability +
-        ", incubationTime=" + incubationTime +
-        ", mortalityRisk=" + mortalityRisk +
-        ", infectionTime=" + infectionTime +
-        ", immunityChance=" + immunityChance +
-        ", hospitalCapacity=" + hospitalCapacity +
-        ", isolationProbability=" + isolationProbability +
-        ", hospitalProbability=" + hospitalProbability +
-        ", childrenRatio=" + childrenRatio +
-        ", adultRatio=" + adultRatio +
-        ", elderlyRatio=" + elderlyRatio +
-        '}';
-  }
+    public void setLockdownEffect(int lockdownEffect) {
+        this.lockdownEffect = lockdownEffect;
+    }
+
+    public int getConfiguredIncubationTime() {
+        return configuredIncubationTime;
+    }
+
+    public void setConfiguredIncubationTime(int configuredIncubationTime) {
+        this.configuredIncubationTime = configuredIncubationTime;
+    }
+
+    public int getConfiguredInfectionTime() {
+        return configuredInfectionTime;
+    }
+
+    public void setConfiguredInfectionTime(int configuredInfectionTime) {
+        this.configuredInfectionTime = configuredInfectionTime;
+    }
+
+    @Override
+    public String toString() {
+        return "Config{"
+                + "infectionRadius=" + infectionRadius
+                + ", infectionProbability=" + infectionProbability
+                + ", incubationTime=" + incubationTime
+                + ", mortalityRisk=" + mortalityRisk
+                + ", infectionTime=" + infectionTime
+                + ", immunityChance=" + immunityChance
+                + ", hospitalCapacity=" + hospitalCapacity
+                + ", isolationProbability=" + isolationProbability
+                + ", hospitalProbability=" + hospitalProbability
+                + ", childrenRatio=" + childrenRatio
+                + ", adultRatio=" + adultRatio
+                + ", elderlyRatio=" + elderlyRatio
+                + '}';
+    }
 }

--- a/src/com/biocollapse/view/ConfigPanel.java
+++ b/src/com/biocollapse/view/ConfigPanel.java
@@ -6,7 +6,6 @@ import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import src.com.biocollapse.controller.WindowController;
-import src.com.biocollapse.model.Config;
 import src.com.biocollapse.util.GlobalConfig;
 
 public class ConfigPanel extends JTabbedPane {
@@ -121,9 +120,9 @@ public class ConfigPanel extends JTabbedPane {
         // Virus Sliders
         infectionRadiusSlider = new JSlider(1, 10, GlobalConfig.config.getInfectionRadius());
         infectionProbabilitySlider = new JSlider(0, 100, GlobalConfig.config.getInfectionProbability());
-        incubationTimeSlider = new JSlider(0, 5, (int) (GlobalConfig.config.getIncubationTime() / Config.SIMULATION_ONE_DAY_TICKS));
+        incubationTimeSlider = new JSlider(0, 5, GlobalConfig.config.getConfiguredIncubationTime());
         mortalityRateSlider = new JSlider(0, 100, GlobalConfig.config.getMortalityRisk());
-        timeToDeathSlider = new JSlider(1, 20, (int) (GlobalConfig.config.getIncubationTime() / Config.SIMULATION_ONE_DAY_TICKS) > 0 ? (int) (GlobalConfig.config.getIncubationTime() / Config.SIMULATION_ONE_DAY_TICKS) : 1);
+        timeToDeathSlider = new JSlider(1, 20, GlobalConfig.config.getConfiguredInfectionTime());
         immunityChanceSlider = new JSlider(0, 100, GlobalConfig.config.getImmunityChance());
 
         // Population Sliders
@@ -205,9 +204,9 @@ public class ConfigPanel extends JTabbedPane {
         // Save Config parameters
         int infectionRadius = infectionRadiusSlider.getValue();
         int infectionProbability = infectionProbabilitySlider.getValue();
-        int incubationTime = incubationTimeSlider.getValue() * Config.SIMULATION_ONE_DAY_TICKS;
+        int incubationTime = incubationTimeSlider.getValue();
         int mortalityRate = mortalityRateSlider.getValue();
-        int timeToDeath = timeToDeathSlider.getValue() * Config.SIMULATION_ONE_DAY_TICKS;
+        int timeToDeath = timeToDeathSlider.getValue();
         int immunityChance = immunityChanceSlider.getValue();
 
         int hospitalCapacity = hospitalCapacitySlider.getValue();


### PR DESCRIPTION
Please test, that the config parameter timeToDeath is now saved for editing when adjusting existing prameters.

Previously the value and slider state was not restored from the existing config.

(file changed alot due to using formatter accidently :/)