### PR TITLE
Restructured the updateHumanGoal function

### DIFF
--- a/src/com/biocollapse/service/InfectionService.java
+++ b/src/com/biocollapse/service/InfectionService.java
@@ -136,7 +136,7 @@ public class InfectionService {
                     human.setAlive(false);
                 } else {
                     human.setInfected(false);
-
+                    human.setInfectedDecisionMade(false);
                     // Adults have a better chance at becoming immune than children and the elderly
                     int effectiveImmunityChance = humanAge == Age.Adult
                             ? immunityChance + immunityChance / 2


### PR DESCRIPTION
I have started to put some more thought into the updateHumanGoal function.

If a human is infected, he now only makes the decision once about what he wants to do and not once for each tick at which the human is infected. This prevents people from always going to hospital.

In addition, a person now has three options to choose from as soon as they are infected.
1. he goes to hospital. (Adjustable by the hospitalisation probability)
2. isolate themselves at home. (Adjustable by the home quarantine probability)
3. he continues to live his life as if he were healthy. (If none of the other options apply)

In addition, the isolation, school closure and lockdown measures now work correctly.
- In isolation, the home quarantine probability is 100%
- During lockdown or school closures, everyone stays home unless someone is sick. Then someone follows the 3 probabilities as described above.

Please test a little more carefully here and consider whether the code makes sense. I am open to questions and hope that we can make progress with it :)