### PR TITLE
Fixed: now the summary only shows two digits after the dot for percen…

### DIFF
--- a/src/com/biocollapse/controller/SimulationController.java
+++ b/src/com/biocollapse/controller/SimulationController.java
@@ -135,7 +135,7 @@ public class SimulationController {
                         .append(currentStatistics.getAlive())
                         .append(" Menschen ")
                         .append("(")
-                        .append((double) currentStatistics.getAlive() / humans.size() * 100)
+                        .append(String.format("%.2f", (double) currentStatistics.getAlive() / humans.size() * 100))
                         .append("%)")
                         .append(" überlebt.");
             }
@@ -144,13 +144,13 @@ public class SimulationController {
                     .append(currentStatistics.getImmune())
                     .append(" Menschen ")
                     .append("(")
-                    .append((double) currentStatistics.getImmune() / humans.size() * 100)
+                    .append(String.format("%.2f", (double) currentStatistics.getImmune() / humans.size() * 100))
                     .append("%)")
                     .append(" immun geworden und ")
                     .append(currentStatistics.getDeaths())
                     .append(" Menschen ")
                     .append("(")
-                    .append((double) currentStatistics.getDeaths() / humans.size() * 100)
+                    .append(String.format("%.2f", (double) currentStatistics.getDeaths() / humans.size() * 100))
                     .append("%)")
                     .append(" gestorben");
         }


### PR DESCRIPTION
The percentage calculations sometimes showed super many digits after the dot.

It made me mildy annoyed after some time :smiling_face_with_tear: 

Now only two digits are visible.

